### PR TITLE
tasks/import/stations: The CSV is in the repo again

### DIFF
--- a/lib/tasks/import/stations.rake
+++ b/lib/tasks/import/stations.rake
@@ -4,7 +4,7 @@ require 'rest-client'
 namespace :import do
   desc 'Import the list of current UK railway stations.'
   task :stations do
-    CSV.parse(RestClient.get('https://www.nationalrail.co.uk/static/documents/content/station_codes.csv').body).each do |name, abbr|
+    CSV.foreach("public/uk_national_rail_stations.csv") do |name, abbr|
       next if name == "Station Name" && abbr == "CRS Code"
 
       Station.create(name: name, abbr: abbr) unless Station.find_by(name: name)

--- a/public/uk_national_rail_stations.csv
+++ b/public/uk_national_rail_stations.csv
@@ -1,0 +1,2581 @@
+Station Name,CRS Code
+Abbey Wood,ABW
+Aber,ABE
+Abercynon,ACY
+Aberdare,ABA
+Aberdeen,ABD
+Aberdour,AUR
+Aberdovey,AVY
+Abererch,ABH
+Abergavenny,AGV
+Abergele & Pensarn,AGL
+Aberystwyth,AYW
+Accrington,ACR
+Achanalt,AAT
+Achnasheen,ACN
+Achnashellach,ACH
+Acklington,ACK
+Acle,ACL
+Acocks Green,ACG
+Acton Bridge (Cheshire),ACB
+Acton Central,ACC
+Acton Main Line,AML
+Adderley Park,ADD
+Addiewell,ADW
+Addlestone,ASN
+Adisham,ADM
+Adlington (Cheshire),ADC
+Adlington (Lancs),ADL
+Adwick,AWK
+Aigburth,AIG
+Ainsdale,ANS
+Aintree,AIN
+Airbles,AIR
+Airdrie,ADR
+Albany Park,AYP
+Albrighton,ALB
+Alderley Edge,ALD
+Aldermaston,AMT
+Aldershot,AHT
+Aldrington,AGT
+Alexandra Palace,AAP
+Alexandra Parade,AXP
+Alexandria,ALX
+Alfreton,ALF
+Allens West,ALW
+Alloa,ALO
+Alness,ASS
+Alnmouth,ALM
+Alresford (Essex),ALR
+Alsager,ASG
+Althorne (Essex),ALN
+Althorpe,ALP
+Altnabreac,ABC
+Alton,AON
+Altrincham,ALT
+Alvechurch,ALV
+Ambergate,AMB
+Amberley,AMY
+Amersham,AMR
+Ammanford,AMF
+Ancaster,ANC
+Anderston,AND
+Andover,ADV
+Anerley,ANZ
+Angmering,ANG
+Annan,ANN
+Anniesland,ANL
+Ansdell & Fairhaven,AFV
+Apperley Bridge,APY
+Appleby,APP
+Appledore (Kent),APD
+Appleford,APF
+Appley Bridge,APB
+Apsley,APS
+Arbroath,ARB
+Ardgay,ARD
+Ardlui,AUI
+Ardrossan Harbour,ADS
+Ardrossan South Beach,ASB
+Ardrossan Town,ADN
+Ardwick,ADK
+Argyle Street,AGS
+Arisaig,ARG
+Arlesey,ARL
+Armadale (West Lothian),ARM
+Armathwaite,AWT
+Arnside,ARN
+Arram,ARR
+Arrochar & Tarbet,ART
+Arundel,ARU
+Ascot (Berks),ACT
+Ascott-under-Wychwood,AUW
+Ash,ASH
+Ash Vale,AHV
+Ashburys,ABY
+Ashchurch for Tewkesbury,ASC
+Ashfield,ASF
+Ashford (Surrey),AFS
+Ashford International,AFK
+Ashford International (Eurostar),ASI
+Ashley,ASY
+Ashtead,AHD
+Ashton-under-Lyne,AHN
+Ashurst (Kent),AHS
+Ashurst New Forest,ANF
+Ashwell & Morden,AWM
+Askam,ASK
+Aslockton,ALK
+Aspatria,ASP
+Aspley Guise,APG
+Aston,AST
+Atherstone,ATH
+Atherton,ATN
+Attadale,ATT
+Attenborough,ATB
+Attleborough,ATL
+Auchinleck,AUK
+Audley End,AUD
+Aughton Park,AUG
+Aviemore,AVM
+Avoncliff,AVF
+Avonmouth,AVN
+Axminster,AXM
+Aylesbury,AYS
+Aylesbury Vale Parkway,AVP
+Aylesford,AYL
+Aylesham,AYH
+Ayr,AYR
+Bache,BAC
+Baglan,BAJ
+Bagshot,BAG
+Baildon,BLD
+Baillieston,BIO
+Balcombe,BAB
+Baldock,BDK
+Balham,BAL
+Balloch,BHC
+Balmossie,BSI
+Bamber Bridge,BMB
+Bamford,BAM
+Banavie,BNV
+Banbury,BAN
+Bangor (Gwynedd),BNG
+Bank Hall,BAH
+Banstead,BAD
+Barassie,BSS
+Barbican,ZBB
+Bardon Mill,BLL
+Bare Lane,BAR
+Bargeddie,BGI
+Bargoed,BGD
+Barking,BKG
+Barlaston,BRT
+Barming,BMG
+Barmouth,BRM
+Barnehurst,BNH
+Barnes,BNS
+Barnes Bridge,BNI
+Barnetby,BTB
+Barnham,BAA
+Barnhill,BNL
+Barnsley,BNY
+Barnstaple,BNP
+Barnt Green,BTG
+Barrhead,BRR
+Barrhill,BRL
+Barrow Haven,BAV
+Barrow-in-Furness,BIF
+Barrow-Upon-Soar,BWS
+Barry,BRY
+Barry Docks,BYD
+Barry Island,BYI
+Barry Links,BYL
+Barton-on-Humber,BAU
+Basildon,BSO
+Basingstoke,BSK
+Bat & Ball,BBL
+Bath Spa,BTH
+Bathgate,BHG
+Batley,BTL
+Battersby,BTT
+Battersea Park,BAK
+Battle,BAT
+Battlesbridge,BLB
+Bayford,BAY
+Beaconsfield,BCF
+Bearley,BER
+Bearsden,BRN
+Bearsted,BSD
+Beasdale,BSL
+Beaulieu Road,BEU
+Beauly,BEL
+Bebington,BEB
+Beccles,BCC
+Beckenham Hill,BEC
+Beckenham Junction,BKJ
+Bedford,BDM
+Bedford St Johns,BSJ
+Bedhampton,BDH
+Bedminster,BMT
+Bedworth,BEH
+Bedwyn,BDW
+Beeston,BEE
+Bekesbourne,BKS
+Belle Vue,BLV
+Bellgrove,BLG
+Bellingham,BGM
+Bellshill,BLH
+Belmont,BLM
+Belper,BLP
+Beltring,BEG
+Belvedere,BVD
+Bempton,BEM
+Ben Rhydding,BEY
+Benfleet,BEF
+Bentham,BEN
+Bentley (Hants),BTY
+Bentley (South Yorks),BYK
+Bere Alston,BAS
+Bere Ferrers,BFE
+Berkhamsted,BKM
+Berkswell,BKW
+Bermuda Park,BEP
+Berney Arms,BYA
+Berry Brow,BBW
+Berrylands,BRS
+Berwick (Sussex),BRK
+Berwick-upon-Tweed,BWK
+Bescar Lane,BES
+Bescot Stadium,BSC
+Betchworth,BTO
+Bethnal Green,BET
+Betws-y-Coed,BYC
+Beverley,BEV
+Bexhill,BEX
+Bexley,BXY
+Bexleyheath,BXH
+Bicester North,BCS
+Bicester Village,BIT
+Bickley,BKL
+Bidston,BID
+Biggleswade,BIW
+Bilbrook,BBK
+Billericay,BIC
+Billingham (Cleveland),BIL
+Billingshurst,BIG
+Bingham,BIN
+Bingley,BIY
+Birchgrove,BCG
+Birchington-on-sea,BCH
+Birchwood,BWD
+Birkbeck,BIK
+Birkdale,BDL
+Birkenhead Central,BKC
+Birkenhead Hamilton Square,BKQ
+Birkenhead North,BKN
+Birkenhead Park,BKP
+Birmingham International,BHI
+Birmingham Moor Street,BMO
+Birmingham New Street,BHM
+Birmingham Snow Hill,BSW
+Bishop Auckland,BIA
+Bishopbriggs,BBG
+Bishops Stortford,BIS
+Bishopstone (Sussex),BIP
+Bishopton (Strathclyde),BPT
+Bitterne,BTE
+Blackburn,BBN
+Blackheath,BKH
+Blackhorse Road,BHO
+Blackpool North,BPN
+Blackpool Pleasure Beach,BPB
+Blackpool South,BPS
+Blackridge,BKR
+Blackrod,BLK
+Blackwater,BAW
+Blaenau Ffestiniog,BFF
+Blair Atholl,BLA
+Blairhill,BAI
+Blake Street,BKT
+Blakedown,BKD
+Blantyre,BLT
+Blaydon,BLO
+Bleasby,BSB
+Bletchley,BLY
+Bloxwich,BLX
+Bloxwich North,BWN
+Blundellsands & Crosby,BLN
+Blythe Bridge,BYB
+Bodmin Parkway,BOD
+Bodorgan,BOR
+Bognor Regis,BOG
+Bogston,BGS
+Bolton,BON
+Bolton-Upon-Dearne,BTD
+Bookham,BKA
+Bootle (Cumbria),BOC
+Bootle New Strand,BNW
+Bootle Oriel Road,BOT
+Bordesley,BBS
+Borough Green & Wrotham,BRG
+Borth,BRH
+Bosham,BOH
+Boston,BSN
+Botley,BOE
+Bottesford,BTF
+Bourne End,BNE
+Bournemouth,BMH
+Bournville,BRV
+Bow Brickhill,BWB
+Bowes Park,BOP
+Bowling,BWG
+Box Hill & Westhumble,BXW
+Bracknell,BCE
+Bradford Forster Square,BDQ
+Bradford Interchange,BDI
+Bradford-on-Avon,BOA
+Brading,BDN
+Braintree,BTR
+Braintree Freeport,BTP
+Bramhall,BML
+Bramley (Hants),BMY
+Bramley (W Yorks),BLE
+Brampton (Cumbria),BMP
+Brampton (Suffolk),BRP
+Branchton,BCN
+Brandon,BND
+Branksome,BSM
+Braystones (Cumbria),BYS
+Bredbury,BDY
+Breich,BRC
+Brentford,BFD
+Brentwood,BRE
+Bricket Wood,BWO
+Bridge of Allan,BEA
+Bridge of Orchy,BRO
+Bridgend,BGN
+Bridgeton,BDG
+Bridgwater,BWT
+Bridlington,BDT
+Brierfield,BRF
+Brigg,BGG
+Brighouse,BGH
+Brighton (East Sussex),BTN
+Brimsdown,BMD
+Brinnington,BNT
+Bristol Parkway,BPW
+Bristol Temple Meads,BRI
+Brithdir,BHD
+Briton Ferry,BNF
+Brixton,BRX
+Broad Green,BGE
+Broadbottom,BDB
+Broadstairs,BSR
+Brockenhurst,BCU
+Brockholes,BHS
+Brockley,BCY
+Bromborough,BOM
+Bromborough Rake,BMR
+Bromley Cross (Lancs),BMC
+Bromley North,BMN
+Bromley South,BMS
+Bromsgrove,BMV
+Brondesbury,BSY
+Brondesbury Park,BSP
+Brookmans Park,BPK
+Brookwood,BKO
+Broome,BME
+Broomfleet,BMF
+Brora,BRA
+Brough,BUH
+Broughty Ferry,BYF
+Broxbourne,BXB
+Bruce Grove,BCV
+Brundall,BDA
+Brundall Gardens,BGA
+Brunstane,BSU
+Brunswick,BRW
+Bruton,BRU
+Bryn,BYN
+Buckenham (Norfolk),BUC
+Buckley,BCK
+Bucknell,BUK
+Buckshaw Parkway,BSV
+Bugle,BGL
+Builth Road,BHR
+Bulwell,BLW
+Bures,BUE
+Burgess Hill,BUG
+Burley Park,BUY
+Burley-in-Wharfedale,BUW
+Burnage,BNA
+Burneside (Cumbria),BUD
+Burnham (Bucks),BNM
+Burnham-on-Crouch,BUU
+Burnley Barracks,BUB
+Burnley Central,BNC
+Burnley Manchester Road,BYM
+Burnside (Strathclyde),BUI
+Burntisland,BTS
+Burscough Bridge,BCB
+Burscough Junction,BCJ
+Bursledon,BUO
+Burton Joyce,BUJ
+Burton-on-Trent,BUT
+Bury St Edmunds,BSE
+Busby,BUS
+Bush Hill Park,BHK
+Bushey,BSH
+Butlers Lane,BUL
+Buxted,BXD
+Buxton,BUX
+Byfleet & New Haw,BFN
+Bynea,BYE
+Cadoxton,CAD
+Caergwrle,CGW
+Caerphilly,CPH
+Caersws,CWS
+Caldercruix,CAC
+Caldicot,CDT
+Caledonian Rd & Barnsbury,CIR
+Calstock,CSK
+Cam & Dursley,CDU
+Camberley,CAM
+Camborne,CBN
+Cambridge,CBG
+Cambridge Heath,CBH
+Cambridge North,CMB
+Cambuslang,CBL
+Camden Road,CMD
+Camelon,CMO
+Canada Water,ZCW
+Canley,CNL
+Cannock,CAO
+Canonbury,CNN
+Canterbury East,CBE
+Canterbury West,CBW
+Cantley,CNY
+Capenhurst,CPU
+Carbis Bay,CBB
+Cardenden,CDD
+Cardiff Bay,CDB
+Cardiff Central,CDF
+Cardiff Queen Street,CDQ
+Cardonald,CDO
+Cardross,CDR
+Carfin,CRF
+Cark & Cartmel,CAK
+Carlisle,CAR
+Carlton,CTO
+Carluke,CLU
+Carmarthen,CMN
+Carmyle,CML
+Carnforth,CNF
+Carnoustie,CAN
+Carntyne,CAY
+Carpenders Park,CPK
+Carrbridge,CAG
+Carshalton,CSH
+Carshalton Beeches,CSB
+Carstairs,CRS
+Cartsdyke,CDY
+Castle Bar Park,CBP
+Castle Cary,CLC
+Castleford,CFD
+Castleton (Manchester),CAS
+Castleton Moor,CSM
+Caterham,CAT
+Catford,CTF
+Catford Bridge,CFB
+Cathays,CYS
+Cathcart,CCT
+Cattal,CTL
+Causeland,CAU
+Cefn-y-Bedd,CYB
+Chadwell Heath,CTH
+Chafford Hundred Lakeside,CFH
+Chalfont & Latimer,CFO
+Chalkwell,CHW
+Chandlers Ford,CFR
+Chapel-en-le-Frith,CEF
+Chapelton (Devon),CPN
+Chapeltown (South Yorks),CLN
+Chappel & Wakes Colne,CWC
+Charing (Kent),CHG
+Charing Cross (Glasgow),CHC
+Charlbury,CBY
+Charlton,CTN
+Chartham,CRT
+Chassen Road,CSR
+Chatelherault,CTE
+Chatham,CTM
+Chathill,CHT
+Cheadle Hulme,CHU
+Cheam,CHE
+Cheddington,CED
+Chelford (Cheshire),CEL
+Chelmsford,CHM
+Chelsfield,CLD
+Cheltenham Spa,CNM
+Chepstow,CPW
+Cherry Tree,CYT
+Chertsey,CHY
+Cheshunt,CHN
+Chessington North,CSN
+Chessington South,CSS
+Chester,CTR
+Chester Road,CRD
+Chesterfield,CHD
+Chester-le-Street,CLS
+Chestfield & Swalecliffe,CSW
+Chetnole,CNO
+Chichester,CCH
+Chilham,CIL
+Chilworth,CHL
+Chingford,CHI
+Chinley,CLY
+Chippenham,CPM
+Chipstead,CHP
+Chirk,CRK
+Chislehurst,CIT
+Chiswick,CHK
+Cholsey,CHO
+Chorley,CRL
+Chorleywood,CLW
+Christchurch,CHR
+Christs Hospital,CHH
+Church & Oswaldtwistle,CTW
+Church Fenton,CHF
+Church Stretton,CTT
+Cilmeri,CIM
+City Thameslink,CTK
+Clacton-on-Sea,CLT
+Clandon,CLA
+Clapham (North Yorkshire),CPY
+Clapham High Street,CLP
+Clapham Junction,CLJ
+Clapton,CPT
+Clarbeston Road,CLR
+Clarkston,CKS
+Claverdon,CLV
+Claygate,CLG
+Cleethorpes,CLE
+Cleland,CEA
+Clifton (Manchester),CLI
+Clifton Down,CFN
+Clitheroe,CLH
+Clock House,CLK
+Clunderwen,CUW
+Clydebank,CYK
+Coatbridge Central,CBC
+Coatbridge Sunnyside,CBS
+Coatdyke,COA
+Cobham & Stoke d'Abernon,CSD
+Codsall,CSL
+Cogan,CGN
+Colchester,COL
+Colchester Town,CET
+Coleshill Parkway,CEH
+Collingham,CLM
+Collington,CLL
+Colne,CNE
+Colwall,CWL
+Colwyn Bay,CWB
+Combe (Oxon),CME
+Commondale,COM
+Congleton,CNG
+Conisbrough,CNS
+Connel Ferry,CON
+Conon Bridge,CBD
+Cononley,CEY
+Conway Park,CNP
+Conwy,CNW
+Cooden Beach,COB
+Cookham,COO
+Cooksbridge,CBR
+Coombe Junction Halt,COE
+Copplestone,COP
+Corbridge,CRB
+Corby,COR
+Corfe Castle,CFC
+Corkerhill,CKH
+Corkickle,CKL
+Corpach,CPA
+Corrour,CRR
+Coryton,COY
+Coseley,CSY
+Cosford,COS
+Cosham,CSA
+Cottingham,CGM
+Cottingley,COT
+Coulsdon South,CDS
+Coulsdon Town,CDN
+Coventry,COV
+Coventry Arena,CAA
+Cowden (Kent),CWN
+Cowdenbeath,COW
+Cradley Heath,CRA
+Craigendoran,CGD
+Cramlington,CRM
+Cranbrook (Devon),CBK
+Craven Arms,CRV
+Crawley,CRW
+Crayford,CRY
+Crediton,CDI
+Cressing (Essex),CES
+Cressington,CSG
+Creswell,CWD
+Crewe,CRE
+Crewkerne,CKN
+Crews Hill,CWH
+Crianlarich,CNR
+Criccieth,CCC
+Cricklewood,CRI
+Croftfoot,CFF
+Crofton Park,CFT
+Cromer,CMR
+Cromford,CMF
+Crookston,CKT
+Cross Gates,CRG
+Crossflatts,CFL
+Crosshill,COI
+Crosskeys,CKY
+Crossmyloof,CMY
+Croston,CSO
+Crouch Hill,CRH
+Crowborough,COH
+Crowhurst,CWU
+Crowle,CWE
+Crowthorne,CRN
+Croy,CRO
+Crystal Palace,CYP
+Cuddington,CUD
+Cuffley,CUF
+Culham,CUM
+Culrain,CUA
+Cumbernauld,CUB
+Cupar,CUP
+Curriehill,CUH
+Cuxton,CUX
+Cwmbach,CMH
+Cwmbran,CWM
+Cynghordy,CYN
+Dagenham Dock,DDK
+Daisy Hill,DSY
+Dalgety Bay,DAG
+Dalmally,DAL
+Dalmarnock,DAK
+Dalmeny,DAM
+Dalmuir,DMR
+Dalreoch,DLR
+Dalry,DLY
+Dalston (Cumbria),DLS
+Dalston Junction,DLJ
+Dalston Kingsland,DLK
+Dalton (Cumbria),DLT
+Dalwhinnie,DLW
+Danby,DNY
+Danescourt,DCT
+Danzey,DZY
+Darlington,DAR
+Darnall,DAN
+Darsham,DSM
+Dartford,DFD
+Darton,DRT
+Darwen,DWN
+Datchet,DAT
+Davenport,DVN
+Dawlish,DWL
+Dawlish Warren,DWW
+Deal,DEA
+Dean (Wilts),DEN
+Deansgate,DGT
+Deganwy,DGY
+Deighton,DHN
+Delamere,DLM
+Denby Dale,DBD
+Denham,DNM
+Denham Golf Club,DGC
+Denmark Hill,DMK
+Dent,DNT
+Denton,DTN
+Deptford,DEP
+Derby,DBY
+Derby Road (Ipswich),DBR
+Devonport (Devon),DPT
+Devonport Dockyard,DOC
+Dewsbury,DEW
+Didcot Parkway,DID
+Digby & Sowton,DIG
+Dilton Marsh,DMH
+Dinas (Rhondda),DMG
+Dinas Powys,DNS
+Dingle Road,DGL
+Dingwall,DIN
+Dinsdale,DND
+Dinting,DTG
+Disley,DSL
+Diss,DIS
+Dodworth,DOD
+Dolau,DOL
+Doleham,DLH
+Dolgarrog,DLG
+Dolwyddelan,DWD
+Doncaster,DON
+Dorchester South,DCH
+Dorchester West,DCW
+Dore & Totley,DOR
+Dorking (Main),DKG
+Dorking Deepdene,DPD
+Dorking West,DKT
+Dormans,DMS
+Dorridge,DDG
+Dove Holes,DVH
+Dover Priory,DVP
+Dovercourt,DVC
+Dovey Junction,DVY
+Downham Market,DOW
+Drayton Green,DRG
+Drayton Park,DYP
+Drem,DRM
+Driffield,DRF
+Drigg,DRI
+Droitwich Spa,DTW
+Dronfield,DRO
+Drumchapel,DMC
+Drumfrochar,DFR
+Drumgelloch,DRU
+Drumry,DMY
+Dublin Ferryport,DFP
+Dublin Port - Stena,DPS
+Duddeston,DUD
+Dudley Port,DDP
+Duffield,DFI
+Duirinish,DRN
+Duke Street,DST
+Dullingham,DUL
+Dumbarton Central,DBC
+Dumbarton East,DBE
+Dumbreck,DUM
+Dumfries,DMF
+Dumpton Park,DMP
+Dunbar,DUN
+Dunblane,DBL
+Duncraig,DCG
+Dundee,DEE
+Dunfermline Queen Margaret,DFL
+Dunfermline Town,DFE
+Dunkeld & Birnam,DKD
+Dunlop,DNL
+Dunrobin Castle,DNO
+Dunston,DOT
+Dunton Green,DNG
+Durham,DHM
+Durrington-on-Sea,DUR
+Dyce,DYC
+Dyffryn Ardudwy,DYF
+Eaglescliffe,EAG
+Ealing Broadway,EAL
+Earlestown,ERL
+Earley,EAR
+Earlsfield,EAD
+Earlswood (Surrey),ELD
+Earlswood (West Midlands),EWD
+East Croydon,ECR
+East Didsbury,EDY
+East Dulwich,EDW
+East Farleigh,EFL
+East Garforth,EGF
+East Grinstead,EGR
+East Kilbride,EKL
+East Malling,EML
+East Midlands Parkway,EMD
+East Tilbury,ETL
+East Worthing,EWR
+Eastbourne,EBN
+Eastbrook,EBK
+Easterhouse,EST
+Eastham Rake,ERA
+Eastleigh,ESL
+Eastrington,EGN
+Ebbsfleet International,EBD
+Ebbw Vale Parkway,EBV
+Ebbw Vale Town,EBB
+Eccles (Manchester),ECC
+Eccles Road,ECS
+Eccleston Park,ECL
+Edale,EDL
+Eden Park,EDN
+Edenbridge,EBR
+Edenbridge Town,EBT
+Edge Hill,EDG
+Edinburgh,EDB
+Edinburgh Gateway,EGY
+Edinburgh Park,EDP
+Edmonton Green,EDR
+Effingham Junction,EFF
+Eggesford,EGG
+Egham,EGH
+Egton,EGT
+Elephant & Castle,EPH
+Elephant & Castle (Underground),ZEL
+Elgin,ELG
+Ellesmere Port,ELP
+Elmers End,ELE
+Elmstead Woods,ESD
+Elmswell,ESW
+Elsecar,ELR
+Elsenham (Essex),ESM
+Elstree & Borehamwood,ELS
+Eltham,ELW
+Elton & Orston,ELO
+Ely,ELY
+Emerson Park,EMP
+Emsworth,EMS
+Energlyn & Churchill Park,ECP
+Enfield Chase,ENC
+Enfield Lock,ENL
+Enfield Town,ENF
+Entwistle,ENT
+Epsom (Surrey),EPS
+Epsom Downs,EPD
+Erdington,ERD
+Eridge,ERI
+Erith,ERH
+Esher,ESH
+Eskbank,EKB
+Essex Road,EXR
+Etchingham,ETC
+Euxton Balshaw Lane,EBA
+Evesham,EVE
+Ewell East,EWE
+Ewell West,EWW
+Exeter Central,EXC
+Exeter St David's,EXD
+Exeter St Thomas,EXT
+Exhibition Centre (Glasgow),EXG
+Exmouth,EXM
+Exton,EXN
+Eynsford,EYN
+Fairbourne,FRB
+Fairfield,FRF
+Fairlie,FRL
+Fairwater,FRW
+Falconwood,FCN
+Falkirk Grahamston,FKG
+Falkirk High,FKK
+Falls of Cruachan,FOC
+Falmer,FMR
+Falmouth Docks,FAL
+Falmouth Town,FMT
+Fareham,FRM
+Farnborough (Main),FNB
+Farnborough North,FNN
+Farncombe,FNC
+Farnham,FNH
+Farningham Road,FNR
+Farnworth,FNW
+Farringdon,ZFD
+Fauldhouse,FLD
+Faversham,FAV
+Faygate,FGT
+Fazakerley,FAZ
+Fearn,FRN
+Featherstone,FEA
+Felixstowe,FLX
+Feltham,FEL
+Feniton,FNT
+Fenny Stratford,FEN
+Fernhill,FER
+Ferriby,FRY
+Ferryside,FYS
+Ffairfach,FFA
+Filey,FIL
+Filton Abbey Wood,FIT
+Finchley Road & Frognal,FNY
+Finsbury Park,FPK
+Finstock,FIN
+Fishbourne (Sussex),FSB
+Fishersgate,FSG
+Fishguard & Goodwick,FGW
+Fishguard Harbour,FGH
+Fiskerton,FSK
+Fitzwilliam,FZW
+Five Ways,FWY
+Fleet,FLE
+Flimby,FLM
+Flint,FLN
+Flitwick,FLT
+Flixton,FLI
+Flowery Field,FLF
+Folkestone Central,FKC
+Folkestone West,FKW
+Ford,FOD
+Forest Gate,FOG
+Forest Hill,FOH
+Formby,FBY
+Forres,FOR
+Forsinard,FRS
+Fort Matilda,FTM
+Fort William,FTW
+Four Oaks,FOK
+Foxfield,FOX
+Foxton,FXN
+Frant,FRT
+Fratton,FTN
+Freshfield,FRE
+Freshford,FFD
+Frimley,FML
+Frinton-on-Sea,FRI
+Frizinghall,FZH
+Frodsham,FRD
+Frome,FRO
+Fulwell,FLW
+Furness Vale,FNV
+Furze Platt,FZP
+Gainsborough Central,GNB
+Gainsborough Lea Road,GBL
+Galashiels,GAL
+Garelochhead,GCH
+Garforth,GRF
+Gargrave,GGV
+Garrowhill,GAR
+Garscadden,GRS
+Garsdale,GSD
+Garston (Hertfordshire),GSN
+Garswood,GSW
+Gartcosh,GRH
+Garth (Mid Glamorgan),GMG
+Garth (Powys),GTH
+Garve,GVE
+Gathurst,GST
+Gatley,GTY
+Gatwick Airport,GTW
+Georgemas Junction,GGJ
+Gerrards Cross,GER
+Gidea Park,GDP
+Giffnock,GFN
+Giggleswick,GIG
+Gilberdyke,GBD
+Gilfach Fargoed,GFF
+Gillingham (Dorset),GIL
+Gillingham (Kent),GLM
+Gilshochill,GSC
+Gipsy Hill,GIP
+Girvan,GIR
+Glaisdale,GLS
+Glan Conwy,GCW
+Glasgow Central,GLC
+Glasgow Queen Street,GLQ
+Glasshoughton,GLH
+Glazebrook,GLZ
+Gleneagles,GLE
+Glenfinnan,GLF
+Glengarnock,GLG
+Glenrothes with Thornton,GLT
+Glossop,GLO
+Gloucester,GCR
+Glynde,GLY
+Gobowen,GOB
+Godalming,GOD
+Godley,GDL
+Godstone,GDN
+Goldthorpe,GOE
+Golf Street,GOF
+Golspie,GOL
+Gomshall,GOM
+Goodmayes,GMY
+Goole,GOO
+Goostrey,GTR
+Gordon Hill,GDH
+Gorebridge,GBG
+Goring & Streatley,GOR
+Goring-by-Sea,GBS
+Gorton,GTO
+Gospel Oak,GPO
+Gourock,GRK
+Gowerton,GWN
+Goxhill,GOX
+Grange Park,GPK
+Grange-Over-Sands,GOS
+Grangetown (Cardiff),GTN
+Grantham,GRA
+Grateley,GRT
+Gravelly Hill,GVH
+Gravesend,GRV
+Grays,GRY
+Great Ayton,GTA
+Great Bentley,GRB
+Great Chesterford,GRC
+Great Coates,GCT
+Great Malvern,GMV
+Great Missenden,GMN
+Great Yarmouth,GYM
+Green Lane,GNL
+Green Road,GNR
+Greenbank,GBK
+Greenfaulds,GRL
+Greenfield,GNF
+Greenford,GFD
+Greenhithe,GNH
+Greenock Central,GKC
+Greenock West,GKW
+Greenwich,GNW
+Gretna Green,GEA
+Grimsby Docks,GMD
+Grimsby Town,GMB
+Grindleford,GRN
+Grosmont,GMT
+Grove Park,GRP
+Guide Bridge,GUI
+Guildford,GLD
+Guiseley,GSY
+Gunnersbury,GUN
+Gunnislake,GSL
+Gunton,GNT
+Gwersyllt,GWE
+Gypsy Lane,GYP
+Habrough,HAB
+Hackbridge,HCB
+Hackney Central,HKC
+Hackney Downs,HAC
+Hackney Wick,HKW
+Haddenham & Thame Parkway,HDM
+Haddiscoe,HAD
+Hadfield,HDF
+Hadley Wood,HDW
+Hag Fold,HGF
+Haggerston,HGG
+Hagley,HAG
+Hairmyres,HMY
+Hale (Manchester),HAL
+Halesworth,HAS
+Halewood,HED
+Halifax,HFX
+Hall Green,HLG
+Hall Road,HLR
+Halling,HAI
+Hall-i'-th'-Wood,HID
+Haltwhistle,HWH
+Ham Street,HMT
+Hamble,HME
+Hamilton Central,HNC
+Hamilton West,HNW
+Hammerton,HMM
+Hampden Park (Sussex),HMD
+Hampstead Heath,HDH
+Hampton (London),HMP
+Hampton Court,HMC
+Hampton Wick,HMW
+Hampton-in-Arden,HIA
+Hamstead (Birmingham),HSD
+Hamworthy,HAM
+Hanborough,HND
+Handforth,HTH
+Hanwell,HAN
+Hapton,HPN
+Harlech,HRL
+Harlesden,HDN
+Harling Road,HRD
+Harlington (Beds),HLN
+Harlow Mill,HWM
+Harlow Town,HWN
+Harold Wood,HRO
+Harpenden,HPD
+Harrietsham,HRM
+Harringay,HGY
+Harringay Green Lanes,HRY
+Harrington,HRR
+Harrogate,HGT
+Harrow & Wealdstone,HRW
+Harrow-on-the-Hill,HOH
+Hartford (Cheshire),HTF
+Hartlebury,HBY
+Hartlepool,HPL
+Hartwood,HTW
+Harwich International,HPQ
+Harwich Town,HWC
+Haslemere,HSL
+Hassocks,HSK
+Hastings,HGS
+Hatch End,HTE
+Hatfield & Stainforth,HFS
+Hatfield (Herts),HAT
+Hatfield Peverel,HAP
+Hathersage,HSG
+Hattersley,HTY
+Hatton,HTN
+Havant,HAV
+Havenhouse,HVN
+Haverfordwest,HVF
+Hawarden,HWD
+Hawarden Bridge,HWB
+Hawkhead,HKH
+Haydon Bridge,HDB
+Haydons Road,HYR
+Hayes & Harlington,HAY
+Hayes (Kent),HYS
+Hayle,HYL
+Haymarket,HYM
+Haywards Heath,HHE
+Hazel Grove,HAZ
+Headcorn,HCN
+Headingley,HDY
+Headstone Lane,HDL
+Heald Green,HDG
+Healing,HLI
+Heath High Level,HHL
+Heath Low Level,HLL
+Heathrow Airport Terminal 4,HAF
+Heathrow Airport Terminal 5,HWV
+"Heathrow Airport Terminals 1, 2 and 3",HXX
+Heaton Chapel,HTC
+Hebden Bridge,HBD
+Heckington,HEC
+Hedge End,HDE
+Hednesford,HNF
+Heighington,HEI
+Helensburgh Central,HLC
+Helensburgh Upper,HLU
+Hellifield,HLD
+Helmsdale,HMS
+Helsby,HSB
+Hemel Hempstead,HML
+Hendon,HEN
+Hengoed,HNG
+Henley-in-Arden,HNL
+Henley-on-Thames,HOT
+Hensall,HEL
+Hereford,HFD
+Herne Bay,HNB
+Herne Hill,HNH
+Hersham,HER
+Hertford East,HFE
+Hertford North,HFN
+Hessle,HES
+Heswall,HSW
+Hever,HEV
+Heworth,HEW
+Hexham,HEX
+Heyford,HYD
+Heysham Port,HHB
+High Brooms,HIB
+High Street (Glasgow),HST
+High Street Kensington Underground,ZHS
+High Wycombe,HWY
+Higham (Kent),HGM
+Highams Park,HIP
+Highbridge & Burnham,HIG
+Highbury & Islington,HHY
+Hightown,HTO
+Hildenborough,HLB
+Hillfoot,HLF
+Hillington East,HLE
+Hillington West,HLW
+Hillside,HIL
+Hilsea,HLS
+Hinchley Wood,HYW
+Hinckley (Leics),HNK
+Hindley,HIN
+Hinton Admiral,HNA
+Hitchin,HIT
+Hither Green,HGR
+Hockley,HOC
+Hollingbourne,HBN
+Holmes Chapel,HCH
+Holmwood,HLM
+Holton Heath,HOL
+Holyhead,HHD
+Holytown,HLY
+Homerton,HMN
+Honeybourne,HYB
+Honiton,HON
+Honley,HOY
+Honor Oak Park,HPA
+Hook,HOK
+Hooton,HOO
+Hope (Derbyshire),HOP
+Hope (Flintshire),HPE
+Hopton Heath,HPT
+Horden,HRE
+Horley,HOR
+Hornbeam Park,HBP
+Hornsey,HRN
+Horsforth,HRS
+Horsham,HRH
+Horsley,HSY
+Horton-in-Ribblesdale,HIR
+Horwich Parkway,HWI
+Hoscar,HSC
+Hough Green,HGN
+Hounslow,HOU
+Hove,HOV
+Hoveton & Wroxham,HXM
+How Wood (Herts),HWW
+Howden,HOW
+Howwood (Renfrewshire),HOZ
+Hoxton,HOX
+Hoylake,HYK
+Hubberts Bridge,HBB
+Hucknall,HKN
+Huddersfield,HUD
+Hull,HUL
+Humphrey Park,HUP
+Huncoat,HCT
+Hungerford,HGD
+Hunmanby,HUB
+Huntingdon,HUN
+Huntly,HNT
+Hunts Cross,HNX
+Hurst Green,HUR
+Hutton Cranswick,HUT
+Huyton,HUY
+Hyde Central,HYC
+Hyde North,HYT
+Hykeham,HKM
+Hyndland,HYN
+Hythe (Essex),HYH
+IBM Halt,IBM
+Ifield,IFI
+Ilford,IFD
+Ilkeston,ILN
+Ilkley,ILK
+Imperial Wharf,IMW
+Ince & Elton,INE
+Ince (Manchester),INC
+Ingatestone,INT
+Insch,INS
+Invergordon,IGD
+Invergowrie,ING
+Inverkeithing,INK
+Inverkip,INP
+Inverness,INV
+Invershin,INH
+Inverurie,INR
+Ipswich,IPS
+Irlam,IRL
+Irvine,IRV
+Isleworth,ISL
+Islip,ISP
+Iver,IVR
+Ivybridge,IVY
+James Cook,JCH
+Jewellery Quarter,JEQ
+Johnston (Pembs),JOH
+Johnstone (Strathclyde),JHN
+Jordanhill,JOR
+Kearsley (Manchester),KSL
+Kearsney (Kent),KSN
+Keighley,KEI
+Keith,KEH
+Kelvedon,KEL
+Kelvindale,KVD
+Kemble,KEM
+Kempston Hardwick,KMH
+Kempton Park Racecourse,KMP
+Kemsing,KMS
+Kemsley,KML
+Kendal,KEN
+Kenilworth,KNW
+Kenley,KLY
+Kennett,KNE
+Kennishead,KNS
+Kensal Green,KNL
+Kensal Rise,KNR
+Kensington Olympia,KPA
+Kent House,KTH
+Kentish Town,KTN
+Kentish Town West,KTW
+Kenton,KNT
+Kents Bank,KBK
+Kettering,KET
+Kew Bridge,KWB
+Kew Gardens,KWG
+Keyham,KEY
+Keynsham,KYN
+Kidbrooke,KDB
+Kidderminster,KID
+Kidsgrove,KDG
+Kidwelly,KWL
+Kilburn High Road,KBN
+Kildale,KLD
+Kildonan,KIL
+Kilgetty,KGT
+Kilmarnock,KMK
+Kilmaurs,KLM
+Kilpatrick,KPT
+Kilwinning,KWN
+Kinbrace,KBC
+Kingham,KGM
+Kinghorn,KGH
+Kings Langley,KGL
+Kings Lynn,KLN
+Kings Norton,KNN
+Kings Nympton,KGN
+Kings Park,KGP
+Kings Sutton,KGS
+Kingsknowe,KGE
+Kingston,KNG
+Kingswood,KND
+Kingussie,KIN
+Kintbury,KIT
+Kirby Cross,KBX
+Kirk Sandall,KKS
+Kirkby (Merseyside),KIR
+Kirkby Stephen,KSW
+Kirkby-in-Ashfield,KKB
+Kirkby-in-Furness,KBF
+Kirkcaldy,KDY
+Kirkconnel,KRK
+Kirkdale,KKD
+Kirkham & Wesham,KKM
+Kirkhill,KKH
+Kirknewton,KKN
+Kirkstall Forge,KLF
+Kirkwood,KWD
+Kirton Lindsey,KTL
+Kiveton Bridge,KIV
+Kiveton Park,KVP
+Knaresborough,KNA
+Knebworth,KBW
+Knighton,KNI
+Knockholt,KCK
+Knottingley,KNO
+Knucklas,KNU
+Knutsford,KNF
+Kyle of Lochalsh,KYL
+Ladybank,LDY
+Ladywell,LAD
+Laindon,LAI
+Lairg,LRG
+Lake,LKE
+Lakenheath,LAK
+Lamphey,LAM
+Lanark,LNK
+Lancaster,LAN
+Lancing,LAC
+Landywood,LAW
+Langbank,LGB
+Langho,LHO
+Langley (Berks),LNY
+Langley Green,LGG
+Langley Mill,LGM
+Langside,LGS
+Langwathby,LGW
+Langwith-Whaley Thorns,LAG
+Lapford,LAP
+Lapworth,LPW
+Larbert,LBT
+Largs,LAR
+Larkhall,LRH
+Laurencekirk,LAU
+Lawrence Hill,LWH
+Layton (Lancs),LAY
+Lazonby & Kirkoswald,LZB
+Lea Bridge,LEB
+Lea Green,LEG
+Lea Hall,LEH
+Leagrave,LEA
+Lealholm,LHM
+Leamington Spa,LMS
+Leasowe,LSW
+Leatherhead,LHD
+Ledbury,LED
+Lee (London),LEE
+Leeds,LDS
+Leicester,LEI
+Leigh (Kent),LIH
+Leigh-on-Sea,LES
+Leighton Buzzard,LBZ
+Lelant,LEL
+Lelant Saltings,LTS
+Lenham,LEN
+Lenzie,LNZ
+Leominster,LEO
+Letchworth Garden City,LET
+Leuchars (for St. Andrews),LEU
+Levenshulme,LVM
+Lewes,LWS
+Lewisham,LEW
+Leyland,LEY
+Leyton Midland Road,LEM
+Leytonstone High Road,LER
+Lichfield City,LIC
+Lichfield Trent Valley,LTV
+Lidlington,LID
+Limehouse,LHS
+Lincoln Central,LCN
+Lingfield,LFD
+Lingwood,LGD
+Linlithgow,LIN
+Liphook,LIP
+Liskeard,LSK
+Liss,LIS
+Lisvane & Thornhill,LVT
+Little Kimble,LTK
+Little Sutton,LTT
+Littleborough,LTL
+Littlehampton,LIT
+Littlehaven,LVN
+Littleport,LTP
+Liverpool Central,LVC
+Liverpool James Street,LVJ
+Liverpool Lime Street,LIV
+Liverpool South Parkway,LPY
+Livingston North,LSN
+Livingston South,LVG
+Llanaber,LLA
+Llanbedr,LBR
+Llanbister Road,LLT
+Llanbradach,LNB
+Llandaf,LLN
+Llandanwg,LDN
+Llandecwyn,LLC
+Llandeilo,LLL
+Llandovery,LLV
+Llandrindod,LLO
+Llandudno,LLD
+Llandudno Junction,LLJ
+Llandybie,LLI
+Llanelli,LLE
+Llanfairfechan,LLF
+Llanfairpwll,LPG
+Llangadog,LLG
+Llangammarch,LLM
+Llangennech,LLH
+Llangynllo,LGO
+Llanharan,LLR
+Llanhilleth,LTH
+Llanishen,LLS
+Llanrwst,LWR
+Llansamlet,LAS
+Llantwit Major,LWM
+Llanwrda,LNR
+Llanwrtyd,LNW
+Llwyngwril,LLW
+Llwynypia,LLY
+Loch Awe,LHA
+Loch Eil Outward Bound,LHE
+Lochailort,LCL
+Locheilside,LCS
+Lochgelly,LCG
+Lochluichart,LCC
+Lochwinnoch,LHW
+Lockerbie,LOC
+Lockwood,LCK
+London Blackfriars,BFR
+London Bridge,LBG
+London Cannon Street,CST
+London Charing Cross,CHX
+London Euston,EUS
+London Fenchurch Street,FST
+London Fields,LOF
+London Kings Cross,KGX
+London Liverpool Street,LST
+London Marylebone,MYB
+London Paddington,PAD
+London Road (Brighton),LRB
+London Road (Guildford),LRD
+London St Pancras (Intl),SPX
+London St Pancras International,STP
+London Victoria,VIC
+London Waterloo,WAT
+London Waterloo East,WAE
+Long Buckby,LBK
+Long Eaton,LGE
+Long Preston,LPR
+Longbeck,LGK
+Longbridge,LOB
+Longcross,LNG
+Longfield,LGF
+Longniddry,LND
+Longport,LPT
+Longton,LGN
+Looe,LOO
+Lostock,LOT
+Lostock Gralam,LTG
+Lostock Hall,LOH
+Lostwithiel,LOS
+Loughborough,LBO
+Loughborough Junction,LGJ
+Low Moor,LMR
+Lowdham,LOW
+Lower Sydenham,LSY
+Lowestoft,LWT
+Ludlow,LUD
+Luton,LUT
+Luton Airport Parkway,LTN
+Luxulyan,LUX
+Lydney,LYD
+Lye (West Midlands),LYE
+Lymington Pier,LYP
+Lymington Town,LYT
+Lympstone Commando,LYC
+Lympstone Village,LYM
+Lytham,LTM
+Macclesfield,MAC
+Machynlleth,MCN
+Maesteg,MST
+Maesteg (Ewenny Road),MEW
+Maghull,MAG
+Maghull North,MNS
+Maiden Newton,MDN
+Maidenhead,MAI
+Maidstone Barracks,MDB
+Maidstone East,MDE
+Maidstone West,MDW
+Malden Manor,MAL
+Mallaig,MLG
+Malton,MLT
+Malvern Link,MVL
+Manchester Airport,MIA
+Manchester Oxford Road,MCO
+Manchester Piccadilly,MAN
+Manchester United Football Ground,MUF
+Manchester Victoria,MCV
+Manea,MNE
+Manningtree,MNG
+Manor Park,MNP
+Manor Road,MNR
+Manorbier,MRB
+Manors,MAS
+Mansfield,MFT
+Mansfield Woodhouse,MSW
+March,MCH
+Marden (Kent),MRN
+Margate,MAR
+Market Harborough,MHR
+Market Rasen,MKR
+Markinch,MNC
+Marks Tey,MKT
+Marlow,MLW
+Marple,MPL
+Marsden (Yorks),MSN
+Marske,MSK
+Marston Green,MGN
+Martin Mill,MTM
+Martins Heron,MAO
+Marton,MTO
+Maryhill,MYH
+Maryland,MYL
+Maryport,MRY
+Matlock,MAT
+Matlock Bath,MTB
+Mauldeth Road,MAU
+Maxwell Park,MAX
+Maybole,MAY
+Maze Hill,MZH
+Meadowhall,MHS
+Meldreth,MEL
+Melksham,MKM
+Melton (Suffolk),MES
+Melton Mowbray,MMO
+Menheniot,MEN
+Menston,MNN
+Meols,MEO
+Meols Cop,MEC
+Meopham,MEP
+Meridian Water,MRW
+Merryton,MEY
+Merstham,MHM
+Merthyr Tydfil,MER
+Merthyr Vale,MEV
+Metheringham,MGM
+MetroCentre,MCE
+Mexborough,MEX
+Micheldever,MIC
+Micklefield,MIK
+Middlesbrough,MBR
+Middlewood,MDL
+Midgham,MDG
+Milford (Surrey),MLF
+Milford Haven,MFH
+Mill Hill (Lancs),MLH
+Mill Hill Broadway,MIL
+Millbrook (Beds),MLB
+Millbrook (Hants),MBK
+Milliken Park,MIN
+Millom,MLM
+Mills Hill (Manchester),MIH
+Milngavie,MLN
+Milton Keynes Central,MKC
+Minffordd,MFF
+Minster,MSR
+Mirfield,MIR
+Mistley,MIS
+Mitcham Eastfields,MTC
+Mitcham Junction,MIJ
+Mobberley,MOB
+Monifieth,MON
+Monks Risborough,MRS
+Montpelier,MTP
+Montrose,MTS
+Moorfields,MRF
+Moorgate,MOG
+Moorside,MSD
+Moorthorpe,MRP
+Morar,MRR
+Morchard Road,MRD
+Morden South,MDS
+Morecambe,MCM
+Moreton (Dorset),MTN
+Moreton (Merseyside),MRT
+Moreton-in-Marsh,MIM
+Morfa Mawddach,MFA
+Morley,MLY
+Morpeth,MPT
+Mortimer,MOR
+Mortlake,MTL
+Moses Gate,MSS
+Moss Side,MOS
+Mossley (Manchester),MSL
+Mossley Hill,MSH
+Mosspark,MPK
+Moston,MSO
+Motherwell,MTH
+Motspur Park,MOT
+Mottingham,MTG
+Mottisfont & Dunbridge,DBG
+Mouldsworth,MLD
+Moulsecoomb,MCB
+Mount Florida,MFL
+Mount Vernon,MTV
+Mountain Ash,MTA
+Muir of Ord,MOO
+Muirend,MUI
+Musselburgh,MUB
+Mytholmroyd,MYT
+Nafferton,NFN
+Nailsea & Backwell,NLS
+Nairn,NRN
+Nantwich,NAN
+Narberth,NAR
+Narborough,NBR
+Navigation Road,NVR
+Neath,NTH
+Needham Market,NMT
+Neilston,NEI
+Nelson,NEL
+Neston,NES
+Netherfield,NET
+Nethertown,NRT
+Netley,NTL
+New Barnet,NBA
+New Beckenham,NBC
+New Brighton,NBN
+New Clee,NCE
+New Cross,NWX
+New Cross Gate,NXG
+New Cumnock,NCK
+New Eltham,NEH
+New Holland,NHL
+New Hythe,NHE
+New Lane,NLN
+New Malden,NEM
+New Mills Central,NMC
+New Mills Newtown,NMN
+New Milton,NWM
+New Pudsey,NPD
+New Southgate,NSG
+Newark Castle,NCT
+Newark North Gate,NNG
+Newbridge,NBE
+Newbury,NBY
+Newbury Racecourse,NRC
+Newcastle,NCL
+Newcourt,NCO
+Newcraighall,NEW
+Newhaven Harbour,NVH
+Newhaven Town,NVN
+Newington,NGT
+Newmarket,NMK
+Newport (Essex),NWE
+Newport (South Wales),NWP
+Newquay,NQY
+Newstead,NSD
+Newton (Lanark),NTN
+Newton Abbot,NTA
+Newton Aycliffe,NAY
+Newton for Hyde,NWN
+Newton St Cyres,NTC
+Newtongrange,NEG
+Newton-le-Willows,NLW
+Newtonmore,NWR
+Newton-on-Ayr,NOA
+Newtown (Powys),NWT
+Ninian Park,NNP
+Nitshill,NIT
+Norbiton,NBT
+Norbury,NRB
+Normans Bay,NSB
+Normanton,NOR
+North Berwick,NBW
+North Camp,NCM
+North Dulwich,NDL
+North Fambridge,NFA
+North Llanrwst,NLR
+North Queensferry,NQU
+North Road (Darlington),NRD
+North Sheen,NSH
+North Walsham,NWA
+North Wembley,NWB
+Northallerton,NTR
+Northampton,NMP
+Northfield,NFD
+Northfleet,NFL
+Northolt Park,NLT
+Northumberland Park,NUM
+Northwich,NWI
+Norwich,NRW
+Norwood Junction,NWD
+Nottingham,NOT
+Nuneaton,NUN
+Nunhead,NHD
+Nunthorpe,NNT
+Nutbourne,NUT
+Nutfield,NUF
+Oakengates,OKN
+Oakham,OKM
+Oakleigh Park,OKL
+Oban,OBN
+Ockendon,OCK
+Ockley,OLY
+Okehampton,OKE
+Okehampton,OKE
+Old Hill,OHL
+Old Roan,ORN
+Old Street,OLD
+Oldfield Park,OLF
+Olton,OLT
+Ore,ORE
+Ormskirk,OMS
+Orpington,ORP
+Orrell,ORR
+Orrell Park,OPK
+Otford,OTF
+Oulton Broad North,OUN
+Oulton Broad South,OUS
+Outwood,OUT
+Overpool,OVE
+Overton,OVR
+Oxenholme Lake District,OXN
+Oxford,OXF
+Oxford Parkway,OXP
+Oxshott,OXS
+Oxted,OXT
+Paddock Wood,PDW
+Padgate,PDG
+Paignton,PGN
+Paisley Canal,PCN
+Paisley Gilmour Street,PYG
+Paisley St James,PYJ
+Palmers Green,PAL
+Pangbourne,PAN
+Pannal,PNL
+Pantyffynnon,PTF
+Par,PAR
+Parbold,PBL
+Park Street,PKT
+Parkstone (Dorset),PKS
+Parson Street,PSN
+Partick,PTK
+Parton,PRN
+Patchway,PWY
+Patricroft,PAT
+Patterton,PTT
+Peartree,PEA
+Peckham Rye,PMR
+Pegswood,PEG
+Pemberton,PEM
+Pembrey & Burry Port,PBY
+Pembroke,PMB
+Pembroke Dock,PMD
+Penally,PNA
+Penarth,PEN
+Pencoed,PCD
+Pengam,PGM
+Penge East,PNE
+Penge West,PNW
+Penhelig,PHG
+Penistone,PNS
+Penkridge,PKG
+Penmaenmawr,PMW
+Penmere,PNM
+Penrhiwceiber,PER
+Penrhyndeudraeth,PRH
+Penrith (North Lakes),PNR
+Penryn (Cornwall),PYN
+Pensarn (Gwynedd),PES
+Penshurst,PHR
+Pentre-Bach,PTB
+Pen-y-Bont,PNY
+Penychain,PNC
+Penyffordd,PNF
+Penzance,PNZ
+Perranwell,PRW
+Perry Barr,PRY
+Pershore,PSH
+Perth,PTH
+Peterborough,PBO
+Petersfield,PTR
+Petts Wood,PET
+Pevensey & Westham,PEV
+Pevensey Bay,PEB
+Pewsey,PEW
+Pilning,PIL
+Pinhoe,PIN
+Pitlochry,PIT
+Pitsea,PSE
+Pleasington,PLS
+Plockton,PLK
+Pluckley,PLC
+Plumley,PLM
+Plumpton,PMP
+Plumstead,PLU
+Plymouth,PLY
+Pokesdown,POK
+Polegate,PLG
+Polesworth,PSW
+Pollokshaws East,PWE
+Pollokshaws West,PWW
+Pollokshields East,PLE
+Pollokshields West,PLW
+Polmont,PMT
+Polsloe Bridge,POL
+Ponders End,PON
+Pontarddulais,PTD
+Pontefract Baghill,PFR
+Pontefract Monkhill,PFM
+Pontefract Tanshelf,POT
+Pontlottyn,PLT
+Pontyclun,PYC
+Pont-y-Pant,PYP
+Pontypool & New Inn,PPL
+Pontypridd,PPD
+Poole,POO
+Poppleton,POP
+Port Glasgow,PTG
+Port Sunlight,PSL
+Port Talbot Parkway,PTA
+Portchester,PTC
+Porth,POR
+Porthmadog,PTM
+Portlethen,PLN
+Portslade,PLD
+Portsmouth & Southsea,PMS
+Portsmouth Arms,PMA
+Portsmouth Harbour,PMH
+Possilpark & Parkhouse,PPK
+Potters Bar,PBR
+Poulton-le-Fylde,PFY
+Poynton,PYT
+Prees,PRS
+Prescot,PSC
+Prestatyn,PRT
+Prestbury,PRB
+Preston (Lancs),PRE
+Preston Park,PRP
+Prestonpans,PST
+Prestwick International Airport,PRA
+Prestwick Town,PTW
+Priesthill & Darnley,PTL
+Princes Risborough,PRR
+Prittlewell,PRL
+Prudhoe,PRU
+Pulborough,PUL
+Purfleet,PFL
+Purley,PUR
+Purley Oaks,PUO
+Putney,PUT
+Pwllheli,PWL
+Pye Corner,PYE
+Pyle,PYL
+Quakers Yard,QYD
+Queenborough,QBR
+Queens Park (Glasgow),QPK
+Queens Park (London),QPW
+Queens Road (Peckham),QRP
+Queenstown Road (Battersea),QRB
+Quintrell Downs,QUI
+Radcliffe-on-Trent,RDF
+Radlett,RDT
+Radley,RAD
+Radyr,RDR
+Rainford,RNF
+Rainham (Essex),RNM
+Rainham (Kent),RAI
+Rainhill,RNH
+Ramsgate,RAM
+Ramsgreave & Wilpshire,RGW
+Rannoch,RAN
+Rauceby,RAU
+Ravenglass for Eskdale,RAV
+Ravensbourne,RVB
+Ravensthorpe,RVN
+Rawcliffe,RWC
+Rayleigh,RLG
+Raynes Park,RAY
+Reading,RDG
+Reading West,RDW
+Rectory Road,REC
+Redbridge,RDB
+Redcar British Steel,RBS
+Redcar Central,RCC
+Redcar East,RCE
+Reddish North,RDN
+Reddish South,RDS
+Redditch,RDC
+Redhill,RDH
+Redland,RDA
+Redruth,RED
+Reedham (Norfolk),REE
+Reedham (Surrey),RHM
+Reigate,REI
+Renton,RTN
+Retford,RET
+Rhiwbina,RHI
+Rhoose Cardiff International Airport,RIA
+Rhosneigr,RHO
+Rhyl,RHL
+Rhymney,RHY
+Ribblehead,RHD
+Rice Lane,RIL
+Richmond (London),RMD
+Rickmansworth,RIC
+Riddlesdown,RDD
+Ridgmont,RID
+Riding Mill,RDM
+Risca & Pontymister,RCA
+Rishton,RIS
+Robertsbridge,RBR
+Robroyston,RRN
+Roby,ROB
+Rochdale,RCD
+Roche,ROC
+Rochester,RTR
+Rochford,RFD
+Rock Ferry,RFY
+Rogart,ROG
+Rogerstone,ROR
+Rolleston,ROL
+Roman Bridge,RMB
+Romford,RMF
+Romiley,RML
+Romsey,ROM
+Roose,ROO
+Rose Grove,RSG
+Rose Hill Marple,RSH
+Rosyth,ROS
+Rotherham Central,RMC
+Rotherhithe,ROE
+Roughton Road,RNR
+Rowlands Castle,RLN
+Rowley Regis,ROW
+Roy Bridge,RYB
+Roydon,RYN
+Royston,RYS
+Ruabon,RUA
+Rufford,RUF
+Rugby,RUG
+Rugeley Town,RGT
+Rugeley Trent Valley,RGL
+Runcorn,RUN
+Runcorn East,RUE
+Ruskington,RKT
+Ruswarp,RUS
+Rutherglen,RUT
+Ryde Esplanade,RYD
+Ryde Pier Head,RYP
+Ryde St Johns Road,RYR
+Ryder Brow,RRB
+Rye (Sussex),RYE
+Rye House,RYH
+Salford Central,SFD
+Salford Crescent,SLD
+Salfords (Surrey),SAF
+Salhouse,SAH
+Salisbury,SAL
+Saltaire,SAE
+Saltash,STS
+Saltburn,SLB
+Saltcoats,SLT
+Saltmarshe,SAM
+Salwick,SLW
+Sampford Courtenay,SMC
+Sandal & Agbrigg,SNA
+Sandbach,SDB
+Sanderstead,SNR
+Sandhills,SDL
+Sandhurst (Berks),SND
+Sandling,SDG
+Sandown,SAN
+Sandplace,SDP
+Sandwell & Dudley,SAD
+Sandwich,SDW
+Sandy,SDY
+Sankey for Penketh,SNK
+Sanquhar,SQH
+Sarn,SRR
+Saundersfoot,SDF
+Saunderton,SDR
+Sawbridgeworth,SAW
+Saxilby,SXY
+Saxmundham,SAX
+Scarborough,SCA
+Scotscalder,SCT
+Scotstounhill,SCH
+Scunthorpe,SCU
+Sea Mills,SML
+Seaford (Sussex),SEF
+Seaforth & Litherland,SFL
+Seaham,SEA
+Seamer,SEM
+Seascale,SSC
+Seaton Carew,SEC
+Seer Green & Jordans,SRG
+Selby,SBY
+Selhurst,SRS
+Sellafield,SEL
+Selling,SEG
+Selly Oak,SLY
+Settle,SET
+Seven Kings,SVK
+Seven Sisters,SVS
+Sevenoaks,SEV
+Severn Beach,SVB
+Severn Tunnel Junction,STJ
+Shadwell,SDE
+Shalford (Surrey),SFR
+Shanklin,SHN
+Shawfair,SFI
+Shawford,SHW
+Shawlands,SHL
+Sheerness-on-Sea,SSS
+Sheffield,SHF
+Shelford (Cambs),SED
+Shenfield,SNF
+Shenstone,SEN
+Shepherd's Bush,SPB
+Shepherds Well,SPH
+Shepley,SPY
+Shepperton,SHP
+Shepreth,STH
+Sherborne,SHE
+Sherburn-in-Elmet,SIE
+Sheringham,SHM
+Shettleston,SLS
+Shieldmuir,SDM
+Shifnal,SFN
+Shildon,SHD
+Shiplake,SHI
+Shipley (Yorks),SHY
+Shippea Hill,SPP
+Shipton,SIP
+Shirebrook,SHB
+Shirehampton,SHH
+Shireoaks,SRO
+Shirley,SRL
+Shoeburyness,SRY
+Sholing,SHO
+Shoreditch High Street,SDC
+Shoreham (Kent),SEH
+Shoreham-by-Sea,SSE
+Shortlands,SRT
+Shotton,SHT
+Shotts,SHS
+Shrewsbury,SHR
+Sidcup,SID
+Sileby,SIL
+Silecroft,SIC
+Silkstone Common,SLK
+Silver Street,SLV
+Silverdale,SVR
+Singer,SIN
+Sittingbourne,SIT
+Skegness,SKG
+Skewen,SKE
+Skipton,SKI
+Slade Green,SGR
+Slaithwaite,SWT
+Slateford,SLA
+Sleaford,SLR
+Sleights,SLH
+Slough,SLO
+Small Heath,SMA
+Smallbrook Junction,SAB
+Smethwick Galton Bridge,SGB
+Smethwick Rolfe Street,SMR
+Smithy Bridge,SMB
+Snaith,SNI
+Snodland,SDA
+Snowdown,SWO
+Sole Street,SOR
+Solihull,SOL
+Somerleyton,SYT
+South Acton,SAT
+South Bank,SBK
+South Bermondsey,SBM
+South Croydon,SCY
+South Elmsall,SES
+South Greenford,SGN
+South Gyle,SGL
+South Hampstead,SOH
+South Kenton,SOK
+South Merton,SMO
+South Milford,SOM
+South Ruislip,SRU
+South Tottenham,STO
+South Wigston,SWS
+South Woodham Ferrers,SOF
+Southall,STL
+Southampton Airport Parkway,SOA
+Southampton Central,SOU
+Southbourne,SOB
+Southbury,SBU
+Southease,SEE
+Southend Airport,SIA
+Southend Central,SOC
+Southend East,SOE
+Southend Victoria,SOV
+Southminster,SMN
+Southport,SOP
+Southwick,SWK
+Sowerby Bridge,SOW
+Spalding,SPA
+Spean Bridge,SBR
+Spital,SPI
+Spondon,SPO
+Spooner Row,SPN
+Spring Road,SRI
+Springburn,SPR
+Springfield,SPF
+Squires Gate,SQU
+St Albans Abbey,SAA
+St Albans City,SAC
+St Andrews Road,SAR
+St Annes-on-Sea,SAS
+St Austell,SAU
+St Bees,SBS
+St Budeaux Ferry Road,SBF
+St Budeaux Victoria Road,SBV
+St Columb Road,SCR
+St Denys,SDN
+St Erth,SER
+St Germans,SGM
+St Helens Central,SNH
+St Helens Junction,SHJ
+St Helier (Surrey),SIH
+St Ives (Cornwall),SIV
+St James Park (Exeter),SJP
+St James Street (Walthamstow),SJS
+St Johns (London),SAJ
+St Keyne Wishing Well Halt,SKN
+St Leonards Warrior Square,SLQ
+St Margarets (Herts),SMT
+St Margarets (London),SMG
+St Mary Cray,SMY
+St Michaels,STM
+St Neots,SNO
+Stafford,STA
+Staines,SNS
+Stallingborough,SLL
+Stalybridge,SYB
+Stamford (Lincs),SMD
+Stamford Hill,SMH
+Stanford-le-Hope,SFO
+Stanlow & Thornton,SNT
+Stansted Airport,SSD
+Stansted Mountfitchet,SST
+Staplehurst,SPU
+Stapleton Road,SRD
+Starbeck,SBE
+Starcross,SCS
+Staveley (Cumbria),SVL
+Stechford,SCF
+Steeton & Silsden,SON
+Stepps,SPS
+Stevenage,SVG
+Stevenston,STV
+Stewartby,SWR
+Stewarton,STT
+Stirling,STG
+Stockport,SPT
+Stocksfield,SKS
+Stocksmoor,SSM
+Stockton,STK
+Stoke Mandeville,SKM
+Stoke Newington,SKW
+Stoke-on-Trent,SOT
+Stone (Staffs),SNE
+Stone Crossing,SCG
+Stonebridge Park,SBP
+Stonegate,SOG
+Stonehaven,STN
+Stonehouse,SHU
+Stoneleigh,SNL
+Stourbridge Junction,SBJ
+Stourbridge Town,SBT
+Stow,SOI
+Stowmarket,SMK
+Stranraer,STR
+Stratford (London),SRA
+Stratford International,SFA
+Stratford-upon-Avon,SAV
+Stratford-upon-Avon Parkway,STY
+Strathcarron,STC
+Strawberry Hill,STW
+Streatham (Greater London),STE
+Streatham Common,SRC
+Streatham Hill,SRH
+Streethouse,SHC
+Strines,SRN
+Stromeferry,STF
+Strood (Kent),SOO
+Stroud (Gloucs),STD
+Sturry,STU
+Styal,SYA
+Sudbury & Harrow Road,SUD
+Sudbury (Suffolk),SUY
+Sudbury Hill Harrow,SDH
+Sugar Loaf,SUG
+Summerston,SUM
+Sunbury,SUU
+Sunderland,SUN
+Sundridge Park,SUP
+Sunningdale,SNG
+Sunnymeads,SNY
+Surbiton,SUR
+Surrey Quays,SQE
+Sutton (Surrey),SUO
+Sutton Coldfield,SUT
+Sutton Common,SUC
+Sutton Parkway,SPK
+Swale,SWL
+Swanley,SAY
+Swanscombe,SWM
+Swansea,SWA
+Swanwick,SNW
+Sway,SWY
+Swaythling,SWG
+Swinderby,SWD
+Swindon (Wilts),SWI
+Swineshead,SWE
+Swinton (Manchester),SNN
+Swinton (South Yorks),SWN
+Sydenham (London),SYD
+Sydenham Hill,SYH
+Syon Lane,SYL
+Syston,SYS
+Tackley,TAC
+Tadworth,TAD
+Taffs Well,TAF
+Tain,TAI
+Talsarnau,TAL
+Talybont,TLB
+Tal-y-Cafn,TLC
+Tame Bridge Parkway,TAB
+Tamworth,TAM
+Taplow,TAP
+Tattenham Corner,TAT
+Taunton,TAU
+Taynuilt,TAY
+Teddington,TED
+Tees-side Airport,TEA
+Teignmouth,TGM
+Telford Central,TFC
+Templecombe,TMC
+Tenby,TEN
+Teynham,TEY
+Thames Ditton,THD
+Thatcham,THA
+Thatto Heath,THH
+The Hawthorns,THW
+The Lakes (Warks),TLK
+Theale,THE
+Theobalds Grove,TEO
+Thetford,TTF
+Thirsk,THI
+Thornaby,TBY
+Thorne North,TNN
+Thorne South,TNS
+Thornford,THO
+Thornliebank,THB
+Thornton Abbey,TNA
+Thornton Heath,TTH
+Thorntonhall,THT
+Thorpe Bay,TPB
+Thorpe Culvert,TPC
+Thorpe-le-Soken,TLS
+Three Bridges,TBD
+Three Oaks,TOK
+Thurgarton,THU
+Thurnscoe,THC
+Thurso,THS
+Thurston,TRS
+Tilbury Town,TIL
+Tile Hill,THL
+Tilehurst,TLH
+Tipton,TIP
+Tir-Phil,TIR
+Tisbury,TIS
+Tiverton Parkway,TVP
+Todmorden,TOD
+Tolworth,TOL
+Ton Pentre,TPN
+Tonbridge,TON
+Tondu,TDU
+Tonfanau,TNF
+Tonypandy,TNP
+Tooting,TOO
+Topsham,TOP
+Torquay,TQY
+Torre,TRR
+Totnes,TOT
+Tottenham Hale,TOM
+Totton,TTN
+Town Green,TWN
+Trafford Park,TRA
+Trefforest,TRF
+Trefforest Estate,TRE
+Trehafod,TRH
+Treherbert,TRB
+Treorchy,TRY
+Trimley,TRM
+Tring,TRI
+Troed-y-rhiw,TRD
+Troon,TRN
+Trowbridge,TRO
+Truro,TRU
+Tulloch,TUL
+Tulse Hill,TUH
+Tunbridge Wells,TBW
+Turkey Street,TUR
+Tutbury & Hatton,TUT
+Tweedbank,TWB
+Twickenham,TWI
+Twyford,TWY
+Ty Croes,TYC
+Ty Glas,TGS
+Tygwyn,TYG
+Tyndrum Lower,TYL
+Tyseley,TYS
+Tywyn,TYW
+Uckfield,UCK
+Uddingston,UDD
+Ulceby,ULC
+Ulleskelf,ULL
+Ulverston,ULV
+Umberleigh,UMB
+University (Birmingham),UNI
+Uphall,UHA
+Upholland,UPL
+Upminster,UPM
+Upper Halliford,UPH
+Upper Holloway,UHL
+Upper Tyndrum,UTY
+Upper Warlingham,UWL
+Upton (Merseyside),UPT
+Upwey,UPW
+Urmston,URM
+Uttoxeter,UTT
+Valley,VAL
+Vauxhall,VXH
+Virginia Water,VIR
+Waddon,WDO
+Wadhurst,WAD
+Wainfleet,WFL
+Wakefield Kirkgate,WKK
+Wakefield Westgate,WKF
+Walkden,WKD
+Wallasey Grove Road,WLG
+Wallasey Village,WLV
+Wallington,WLT
+Wallyford,WAF
+Walmer,WAM
+Walsall,WSL
+Walsden,WDN
+Waltham Cross,WLC
+Walthamstow Central,WHC
+Walthamstow Queen's Road,WMW
+Walton (Merseyside),WAO
+Walton-on-Thames,WAL
+Walton-on-the-Naze,WON
+Wanborough,WAN
+Wandsworth Common,WSW
+Wandsworth Road,WWR
+Wandsworth Town,WNT
+Wanstead Park,WNP
+Wapping,WPE
+Warblington,WBL
+Ware (Herts),WAR
+Wareham (Dorset),WRM
+Wargrave,WGV
+Warminster,WMN
+Warnham,WNH
+Warrington Bank Quay,WBQ
+Warrington Central,WAC
+Warrington West,WAW
+Warwick,WRW
+Warwick Parkway,WRP
+Water Orton,WTO
+Waterbeach,WBC
+Wateringbury,WTR
+Waterloo (Merseyside),WLO
+Watford High Street,WFH
+Watford Junction,WFJ
+Watford North,WFN
+Watlington,WTG
+Watton-at-Stone,WAS
+Waun-Gron Park,WNG
+Wavertree Technology Park,WAV
+Wedgwood,WED
+Weeley,WEE
+Weeton,WET
+Welham Green,WMG
+Welling,WLI
+Wellingborough,WEL
+Wellington (Shropshire),WLN
+Welshpool,WLP
+Welwyn Garden City,WGC
+Welwyn North,WLW
+Wem,WEM
+Wembley Central,WMB
+Wembley Stadium,WCX
+Wemyss Bay,WMS
+Wendover,WND
+Wennington,WNN
+West Allerton,WSA
+West Brompton,WBP
+West Byfleet,WBY
+West Calder,WCL
+West Croydon,WCY
+West Drayton,WDT
+West Dulwich,WDU
+West Ealing,WEA
+West Ham,WEH
+West Hampstead,WHD
+West Hampstead Thameslink,WHP
+West Horndon,WHR
+West Kilbride,WKB
+West Kirby,WKI
+West Malling,WMA
+West Norwood,WNW
+West Ruislip,WRU
+West Runton,WRN
+West St Leonards,WLD
+West Sutton,WSU
+West Wickham,WWI
+West Worthing,WWO
+Westbury (Wilts),WSB
+Westcliff,WCF
+Westcombe Park,WCB
+Westenhanger,WHA
+Wester Hailes,WTA
+Westerfield,WFI
+Westerton,WES
+Westgate-on-Sea,WGA
+Westhoughton,WHG
+Weston Milton,WNM
+Weston-super-Mare,WSM
+Wetheral,WRL
+Weybridge,WYB
+Weymouth,WEY
+Whaley Bridge,WBR
+Whalley (Lancs),WHE
+Whatstandwell,WTS
+Whifflet,WFF
+Whimple,WHM
+Whinhill,WNL
+Whiston,WHN
+Whitby,WTB
+Whitchurch (Cardiff),WHT
+Whitchurch (Hants),WCH
+Whitchurch (Shropshire),WTC
+White Hart Lane,WHL
+White Notley,WNY
+Whitechapel,ZLW
+Whitecraigs,WCR
+Whitehaven,WTH
+Whitland,WTL
+Whitley Bridge,WBD
+Whitlocks End,WTE
+Whitstable,WHI
+Whittlesea,WLE
+Whittlesford Parkway,WLF
+Whitton (London),WTN
+Whitwell (Derbyshire),WWL
+Whyteleafe,WHY
+Whyteleafe South,WHS
+Wick,WCK
+Wickford,WIC
+Wickham Market,WCM
+Widdrington,WDD
+Widnes,WID
+Widney Manor,WMR
+Wigan North Western,WGN
+Wigan Wallgate,WGW
+Wigton,WGT
+Wildmill,WMI
+Willesden Junction,WIJ
+Williamwood,WLM
+Willington,WIL
+Wilmcote,WMC
+Wilmslow,WML
+Wilnecote (Staffs),WNE
+Wimbledon,WIM
+Wimbledon Chase,WBO
+Winchelsea,WSE
+Winchester,WIN
+Winchfield,WNF
+Winchmore Hill,WIH
+Windermere,WDM
+Windsor & Eton Central,WNC
+Windsor & Eton Riverside,WNR
+Winnersh,WNS
+Winnersh Triangle,WTI
+Winsford,WSF
+Wishaw,WSH
+Witham,WTM
+Witley,WTY
+Witton (West Midlands),WTT
+Wivelsfield,WVF
+Wivenhoe,WIV
+Woburn Sands,WOB
+Woking,WOK
+Wokingham,WKM
+Woldingham,WOH
+Wolverhampton,WVH
+Wolverton,WOL
+Wombwell,WOM
+Wood End,WDE
+Wood Street,WST
+Woodbridge,WDB
+Woodgrange Park,WGR
+Woodhall,WDL
+Woodhouse,WDH
+Woodlesford,WDS
+Woodley,WLY
+Woodmansterne,WME
+Woodsmoor,WSR
+Wool,WOO
+Woolston,WLS
+Woolwich Arsenal,WWA
+Woolwich Dockyard,WWD
+Wootton Wawen,WWW
+Worcester Foregate Street,WOF
+Worcester Park,WCP
+Worcester Shrub Hill,WOS
+Worcestershire Parkway,WOP
+Workington,WKG
+Worksop,WRK
+Worle,WOR
+Worplesdon,WPL
+Worstead,WRT
+Worthing,WRH
+Wrabness,WRB
+Wraysbury,WRY
+Wrenbury,WRE
+Wressle,WRS
+Wrexham Central,WXC
+Wrexham General,WRX
+Wye,WYE
+Wylam,WYM
+Wylde Green,WYL
+Wymondham,WMD
+Wythall,WYT
+Yalding,YAL
+Yardley Wood,YRD
+Yarm,YRM
+Yate,YAE
+Yatton,YAT
+Yeoford,YEO
+Yeovil Junction,YVJ
+Yeovil Pen Mill,YVP
+Yetminster,YET
+Ynyswen,YNW
+Yoker,YOK
+York,YRK
+Yorton,YRT
+Ystrad Mynach,YSM
+Ystrad Rhondda,YSR


### PR DESCRIPTION
- This used to be fine, but I forgot to update them so I switched to pulling them direct from National Rail.  National Rail have changed the format of their CSV considerably (it's no longer a single two columns - https://www.nationalrail.co.uk/station_codes%20(06-08-2020).csv) and they seem to regenerate it every few months with a new filename.
